### PR TITLE
Clean up output messages and filenames

### DIFF
--- a/fl_tissue_model_tools/helper.py
+++ b/fl_tissue_model_tools/helper.py
@@ -94,6 +94,31 @@ def load_image(
     return image, pixel_sizes
 
 
+def get_unique_output_filepath(file: Union[str, Path]) -> Union[str, Path]:
+    """Get output path that does not overwrite existing files.
+    If the file already exists, a number is appended to the file name.
+
+    Args:
+        file (Union[str, Path]): Path to the file.
+
+    Returns:
+        Union[str, Path]: Path to the output file.
+    """
+
+    is_pathlib = isinstance(file, Path)
+    file = Path(file)
+    dirname = Path(osp.dirname(file))
+    basename = osp.basename(file)
+    name, ext = osp.splitext(basename)
+    file_num = 1
+    while file.exists():
+        file_num += 1
+        basename = f"{name}-{file_num}{ext}"
+        file = dirname / basename
+
+    return file if is_pathlib else str(file)
+
+
 def get_image_dims(file_path: str) -> Dimensions:
     """Get dimensions of image (Time-Channel-Z-Y-X) from metadata.
 

--- a/fl_tissue_model_tools/script_util.py
+++ b/fl_tissue_model_tools/script_util.py
@@ -6,27 +6,11 @@ from pathlib import Path
 from glob import glob
 import shutil
 import json
-from dataclasses import dataclass
 from typing import Any, Dict, Union, List
 
 from fl_tissue_model_tools import helper
+from fl_tissue_model_tools import success_fail_messages as SFM
 from fl_tissue_model_tools import zstacks as zs
-
-
-@dataclass
-class SFM:
-    """Colorized messages for success/failure output using Ansi escape sequences."""
-
-    red = "\x1b[38;5;1m\x1b[1m"
-    green = "\x1b[38;5;2m\x1b[1m"
-    cyan = "\x1b[38;5;6m\x1b[1m"
-    yellow = "\x1b[38;5;3m\x1b[1m"
-    reset = "\x1b[0m"
-    success = f"{green}[SUCCESS]{reset}"
-    failure = f"{red}[FAILURE]{reset}"
-    warning = f"{yellow}[WARNING]{reset}"
-    all_succeeded = f"{green}[ALL SUCCEEDED]{reset}"
-    failures_present = f"{red}[FAILURES PRESENT]{reset}"
 
 
 DASH = "="

--- a/fl_tissue_model_tools/script_util.py
+++ b/fl_tissue_model_tools/script_util.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict, Union, List
 
 from fl_tissue_model_tools import helper
-from fl_tissue_model_tools import success_fail_messages as SFM
+from fl_tissue_model_tools.success_fail_messages import SFM
 from fl_tissue_model_tools import zstacks as zs
 
 

--- a/fl_tissue_model_tools/success_fail_messages.py
+++ b/fl_tissue_model_tools/success_fail_messages.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SFM:
+    """Colorized messages for success/failure output using Ansi escape sequences."""
+
+    red = "\x1b[38;5;1m\x1b[1m"
+    green = "\x1b[38;5;2m\x1b[1m"
+    cyan = "\x1b[38;5;6m\x1b[1m"
+    yellow = "\x1b[38;5;3m\x1b[1m"
+    reset = "\x1b[0m"
+    success = f"{green}[SUCCESS]{reset}"
+    failure = f"{red}[FAILURE]{reset}"
+    warning = f"{yellow}[WARNING]{reset}"
+    all_succeeded = f"{green}[ALL SUCCEEDED]{reset}"
+    failures_present = f"{red}[FAILURES PRESENT]{reset}"

--- a/fl_tissue_model_tools/zstacks.py
+++ b/fl_tissue_model_tools/zstacks.py
@@ -4,32 +4,12 @@ https://github.com/cmcguinness/focusstack
 
 """
 
-from typing import Optional, Union
 import re
 import os.path as osp
 from glob import glob
 import numpy.typing as npt
 import numpy as np
 import cv2
-
-from fl_tissue_model_tools import helper
-
-
-def simplify_zstack_ids(zstack_ids: list[str]):
-    """Trim identifiers to remove common prefixes and suffixes.
-
-    Args:
-        zstack_ids: List of zstack ids.
-
-    Returns:
-        list[str]: List of zstack ids with common prefixes and suffixes removed.
-
-    """
-    while zstack_ids[0] and all(zid.startswith(zstack_ids[0][0]) for zid in zstack_ids):
-        zstack_ids = [zid[1:] for zid in zstack_ids]
-    while zstack_ids[0] and all(zid.endswith(zstack_ids[0][-1]) for zid in zstack_ids):
-        zstack_ids = [zid[:-1] for zid in zstack_ids]
-    return zstack_ids
 
 
 def find_zstack_image_sequences(input_dir: str):
@@ -59,8 +39,6 @@ def find_zstack_image_sequences(input_dir: str):
         zslice_numbers_in_name.append(
             list(map(int, re.findall(r"(?<=z)\d+", name, re.IGNORECASE)))[::-1]
         )
-
-    zslice_stack_ids = simplify_zstack_ids(zslice_stack_ids)
 
     # Group Z slices by Z stack identifier
     zstacks = {}
@@ -94,7 +72,7 @@ def find_zstack_files(input_dir: str):
     img_paths = list(filter(osp.isfile, glob(osp.join(input_dir, "*"))))
     if any(osp.isdir(fp) for fp in glob(osp.join(input_dir, "*"))):
         raise ValueError("Found both files and directories in input directory")
-    zstack_ids = simplify_zstack_ids([osp.basename(img_path) for img_path in img_paths])
+    zstack_ids = [osp.basename(img_path) for img_path in img_paths]
     return {zs_id: fp for zs_id, fp in zip(zstack_ids, img_paths)}
 
 

--- a/scripts/compute_branches.py
+++ b/scripts/compute_branches.py
@@ -27,6 +27,7 @@ from scipy.ndimage import distance_transform_edt
 
 from fl_tissue_model_tools import helper, models, models_util, defs
 from fl_tissue_model_tools import script_util as su
+from fl_tissue_model_tools import success_fail_messages as SFM
 from fl_tissue_model_tools.transforms import filter_branch_seg_mask, regionprops_image
 from fl_tissue_model_tools.topology import MorseGraph
 from fl_tissue_model_tools.well_mask_generation import (
@@ -119,7 +120,7 @@ def make_well_mask(img: np.ndarray):
     well_mask_coverage = np.sum(well_mask) / well_mask.size
     if well_mask_coverage < 0.4:
         print(
-            f"{su.SFM.warning} Well mask coverage is too low ({well_mask_coverage * 100:.2f}%) "
+            f"{SFM.warning} Well mask coverage is too low ({well_mask_coverage * 100:.2f}%) "
             "so it will not be used for analysis."
         )
         well_mask = np.full_like(img, fill_value=True, dtype=bool)
@@ -172,7 +173,7 @@ def analyze_img(
         # Use pixel size from image metadata if available
         if pix_sizes.X is None:
             print(
-                f"{su.SFM.warning} image_width_microns not provided in the config, "
+                f"{SFM.warning} image_width_microns not provided in the config, "
                 "and could not be inferred from the image metadata. "
                 "Using arbitrary value of 1000 microns."
             )
@@ -468,9 +469,7 @@ def main(args=None):
         args = su.parse_branching_args(arg_defaults)
         ### Load/validate config ###
         if not Path(args.config).is_file():
-            print(
-                f"{su.SFM.failure}Config file {args.config} does not exist.", flush=True
-            )
+            print(f"{SFM.failure}Config file {args.config} does not exist.", flush=True)
             sys.exit(1)
         with open(args.config, "r", encoding="utf8") as config_fp:
             config = json.load(config_fp)
@@ -500,7 +499,7 @@ def main(args=None):
 
     if not Path(model_cfg_path).is_file():
         print(
-            f"{su.SFM.failure}Model config file {model_cfg_path} does not exist.",
+            f"{SFM.failure}Model config file {model_cfg_path} does not exist.",
             flush=True,
         )
         sys.exit(1)
@@ -509,7 +508,7 @@ def main(args=None):
     input_dir = Path(args.in_root)
     if not input_dir.exists():
         print(
-            f"{su.SFM.failure}Input directory {args.in_root} does not exist.",
+            f"{SFM.failure}Input directory {args.in_root} does not exist.",
             flush=True,
         )
         sys.exit(1)
@@ -517,7 +516,7 @@ def main(args=None):
     try:
         su.branching_verify_output_dir(args.out_root)
     except PermissionError as error:
-        print(f"{su.SFM.failure} {error}", flush=True)
+        print(f"{SFM.failure} {error}", flush=True)
         sys.exit(1)
 
     output_dir = Path(args.out_root)
@@ -532,7 +531,7 @@ def main(args=None):
     )
 
     if len(img_paths) == 0:
-        print(f"{su.SFM.failure} Input directory is empty: {args.in_root}", flush=True)
+        print(f"{SFM.failure} Input directory is empty: {args.in_root}", flush=True)
         sys.exit(1)
 
     test_path = img_paths[0]
@@ -554,7 +553,7 @@ def main(args=None):
         }
 
     if len(img_paths) == 0:
-        print(f"{su.SFM.failure}No images found in {input_dir}", flush=True)
+        print(f"{SFM.failure}No images found in {input_dir}", flush=True)
         sys.exit(1)
 
     ### Load model ###

--- a/scripts/compute_branches.py
+++ b/scripts/compute_branches.py
@@ -27,7 +27,7 @@ from scipy.ndimage import distance_transform_edt
 
 from fl_tissue_model_tools import helper, models, models_util, defs
 from fl_tissue_model_tools import script_util as su
-from fl_tissue_model_tools import success_fail_messages as SFM
+from fl_tissue_model_tools.success_fail_messages import SFM
 from fl_tissue_model_tools.transforms import filter_branch_seg_mask, regionprops_image
 from fl_tissue_model_tools.topology import MorseGraph
 from fl_tissue_model_tools.well_mask_generation import (

--- a/scripts/compute_cell_area.py
+++ b/scripts/compute_cell_area.py
@@ -279,9 +279,11 @@ def main(args=None):
     area_prop = np.array(area_prop)
 
     print("... Areas computed successfully.", flush=True)
+    print(su.SFM.success, flush=True)
+    su.section_footer()
 
     ### Save results ###
-    print(f"{os.linesep}Saving results...", flush=True)
+    su.section_header("Saving results...")
 
     img_ids = [img_id.replace("/", "_").replace("\\", "_") for img_id in img_ids]
     area_df = pd.DataFrame(data={"image_id": img_ids, "area_pct": area_prop * 100})
@@ -291,16 +293,14 @@ def main(args=None):
         if args.detect_well:
             # Save masked image
             out_img = all_well_masks[i]
-            out_path = os.path.join(
-                args.out_root, THRESH_SUBDIR, f"{img_id}_well_mask.png"
-            )
-            cv2.imwrite(out_path, out_img)
+            file = os.path.join(args.out_root, THRESH_SUBDIR, f"{img_id}_well_mask.png")
+            file = helper.get_unique_output_filepath(file)
+            cv2.imwrite(file, out_img)
         # Save thresholded image
         out_img = gmm_thresh_all[i].astype(np.uint8)
-        out_path = os.path.join(
-            args.out_root, THRESH_SUBDIR, f"{img_id}_thresholded.png"
-        )
-        cv2.imwrite(out_path, out_img)
+        file = os.path.join(args.out_root, THRESH_SUBDIR, f"{img_id}_thresholded.png")
+        file = helper.get_unique_output_filepath(file)
+        cv2.imwrite(file, out_img)
 
     if args.detect_well:
         print(
@@ -313,6 +313,7 @@ def main(args=None):
     )
 
     area_out_path = os.path.join(args.out_root, CALC_SUBDIR, "cell_area.csv")
+    area_out_path = helper.get_unique_output_filepath(area_out_path)
     area_df.to_csv(area_out_path, index=False)
 
     print(f"... Area calculations saved to:{os.linesep}\t{area_out_path}", flush=True)

--- a/scripts/compute_cell_area.py
+++ b/scripts/compute_cell_area.py
@@ -13,7 +13,7 @@ from fl_tissue_model_tools import defs
 from fl_tissue_model_tools import helper
 from fl_tissue_model_tools import preprocessing as prep
 from fl_tissue_model_tools import script_util as su
-from fl_tissue_model_tools import success_fail_messages as SFM
+from fl_tissue_model_tools.success_fail_messages import SFM
 from fl_tissue_model_tools.well_mask_generation import generate_well_mask
 
 DEFAULT_CONFIG_PATH = str(defs.SCRIPT_CONFIG_DIR / "default_cell_area_computation.json")

--- a/scripts/compute_cell_area.py
+++ b/scripts/compute_cell_area.py
@@ -13,6 +13,7 @@ from fl_tissue_model_tools import defs
 from fl_tissue_model_tools import helper
 from fl_tissue_model_tools import preprocessing as prep
 from fl_tissue_model_tools import script_util as su
+from fl_tissue_model_tools import success_fail_messages as SFM
 from fl_tissue_model_tools.well_mask_generation import generate_well_mask
 
 DEFAULT_CONFIG_PATH = str(defs.SCRIPT_CONFIG_DIR / "default_cell_area_computation.json")
@@ -43,7 +44,7 @@ def load_img(
 
     if img.ndim == 3:
         print(
-            f"{su.SFM.warning} Input images are Z stacks. Creating maximum intensity "
+            f"{SFM.warning} Input images are Z stacks. Creating maximum intensity "
             "Z projections prior to cell area calculation.",
             flush=True,
         )
@@ -221,7 +222,7 @@ def main(args=None):
     try:
         su.cell_area_verify_output_dir(args.out_root, THRESH_SUBDIR, CALC_SUBDIR)
     except PermissionError as error:
-        print(f"{su.SFM.failure} {error}", flush=True)
+        print(f"{SFM.failure} {error}", flush=True)
         sys.exit(1)
 
     ### Load config ###
@@ -229,7 +230,7 @@ def main(args=None):
     try:
         config = su.cell_area_verify_config_file(config_path)
     except FileNotFoundError as error:
-        print(f"{su.SFM.failure} {error}", flush=True)
+        print(f"{SFM.failure} {error}", flush=True)
         sys.exit(1)
 
     su.section_header("Performing Analysis")
@@ -257,7 +258,7 @@ def main(args=None):
         try:
             gs_ds_imgs = prep_images(img_paths, dsamp_size, T=args.time, C=args.channel)
         except OSError as error:
-            print(f"{su.SFM.failure}{error}", flush=True)
+            print(f"{SFM.failure}{error}", flush=True)
             sys.exit(1)
 
         # Well masking
@@ -279,7 +280,7 @@ def main(args=None):
     area_prop = np.array(area_prop)
 
     print("... Areas computed successfully.", flush=True)
-    print(su.SFM.success, flush=True)
+    print(SFM.success, flush=True)
     su.section_footer()
 
     ### Save results ###
@@ -317,7 +318,7 @@ def main(args=None):
     area_df.to_csv(area_out_path, index=False)
 
     print(f"... Area calculations saved to:{os.linesep}\t{area_out_path}", flush=True)
-    print(su.SFM.success, flush=True)
+    print(SFM.success, flush=True)
     print(su.END_SEPARATOR, flush=True)
 
 

--- a/scripts/compute_inv_depth.py
+++ b/scripts/compute_inv_depth.py
@@ -18,7 +18,7 @@ import tensorflow.keras.backend as K
 
 from fl_tissue_model_tools import models, data_prep, defs, helper
 from fl_tissue_model_tools import script_util as su
-from fl_tissue_model_tools import success_fail_messages as SFM
+from fl_tissue_model_tools.success_fail_messages import SFM
 from fl_tissue_model_tools import zstacks as zs
 
 DEFAULT_CONFIG_PATH = str(

--- a/scripts/compute_inv_depth.py
+++ b/scripts/compute_inv_depth.py
@@ -18,6 +18,7 @@ import tensorflow.keras.backend as K
 
 from fl_tissue_model_tools import models, data_prep, defs, helper
 from fl_tissue_model_tools import script_util as su
+from fl_tissue_model_tools import success_fail_messages as SFM
 from fl_tissue_model_tools import zstacks as zs
 
 DEFAULT_CONFIG_PATH = str(
@@ -34,12 +35,12 @@ def main(args=None):
 
     ### Verify input source ###
     if os.path.isfile(args.in_root):
-        print(f"{su.SFM.failure} Input directory is a file: {args.in_root}", flush=True)
+        print(f"{SFM.failure} Input directory is a file: {args.in_root}", flush=True)
         sys.exit(1)
 
     if not os.path.isdir(args.in_root):
         print(
-            f"{su.SFM.failure} Input directory does not exist: {args.in_root}",
+            f"{SFM.failure} Input directory does not exist: {args.in_root}",
             flush=True,
         )
         sys.exit(1)
@@ -47,14 +48,14 @@ def main(args=None):
     zstack_paths = glob(os.path.join(args.in_root, "*"))
 
     if len(zstack_paths) == 0:
-        print(f"{su.SFM.failure} Input directory is empty: {args.in_root}", flush=True)
+        print(f"{SFM.failure} Input directory is empty: {args.in_root}", flush=True)
         sys.exit(1)
 
     ### Verify output destination ###
     try:
         su.inv_depth_verify_output_dir(args.out_root)
     except PermissionError as e:
-        print(f"{su.SFM.failure} {e}", flush=True)
+        print(f"{SFM.failure} {e}", flush=True)
         sys.exit(1)
 
     ### Load best hyperparameters ###
@@ -85,7 +86,7 @@ def main(args=None):
     try:
         config = su.inv_depth_verify_config_file(config_path, n_models)
     except FileNotFoundError as e:
-        print(f"{su.SFM.failure} {e}", flush=True)
+        print(f"{SFM.failure} {e}", flush=True)
         sys.exit(1)
     n_pred_models = config["n_pred_models"]
 
@@ -128,7 +129,7 @@ def main(args=None):
         print(f"... Classifier {i} loaded.", flush=True)
 
     print("All classifiers loaded.", flush=True)
-    print(su.SFM.success, flush=True)
+    print(SFM.success, flush=True)
     su.section_footer()
 
     ### Generate predictions ###
@@ -195,7 +196,7 @@ def main(args=None):
     output_file.to_csv(out_csv_path, index=False)
     print("... Results saved.", flush=True)
 
-    print(su.SFM.success, flush=True)
+    print(SFM.success, flush=True)
     su.section_footer()
 
 

--- a/scripts/compute_inv_depth.py
+++ b/scripts/compute_inv_depth.py
@@ -191,6 +191,7 @@ def main(args=None):
         }
     )
     out_csv_path = os.path.join(args.out_root, "invasion_depth_predictions.csv")
+    out_csv_path = helper.get_unique_output_filepath(out_csv_path)
     output_file.to_csv(out_csv_path, index=False)
     print("... Results saved.", flush=True)
 

--- a/scripts/compute_zproj.py
+++ b/scripts/compute_zproj.py
@@ -8,7 +8,7 @@ import cv2
 
 from fl_tissue_model_tools import defs
 from fl_tissue_model_tools import script_util as su
-from fl_tissue_model_tools import success_fail_messages as SFM
+from fl_tissue_model_tools.success_fail_messages import SFM
 from fl_tissue_model_tools import zstacks as zs
 from fl_tissue_model_tools import helper
 from fl_tissue_model_tools.scripts import compute_cell_area

--- a/scripts/compute_zproj.py
+++ b/scripts/compute_zproj.py
@@ -8,6 +8,7 @@ import cv2
 
 from fl_tissue_model_tools import defs
 from fl_tissue_model_tools import script_util as su
+from fl_tissue_model_tools import success_fail_messages as SFM
 from fl_tissue_model_tools import zstacks as zs
 from fl_tissue_model_tools import helper
 from fl_tissue_model_tools.scripts import compute_cell_area
@@ -36,12 +37,12 @@ def main(args=None):
 
     ### Verify input source ###
     if os.path.isfile(args.in_root):
-        print(f"{su.SFM.failure} Input directory is a file: {args.in_root}", flush=True)
+        print(f"{SFM.failure} Input directory is a file: {args.in_root}", flush=True)
         sys.exit(1)
 
     if not os.path.isdir(args.in_root):
         print(
-            f"{su.SFM.failure} Input directory does not exist: {args.in_root}",
+            f"{SFM.failure} Input directory does not exist: {args.in_root}",
             flush=True,
         )
         sys.exit(1)
@@ -49,7 +50,7 @@ def main(args=None):
     zstack_paths = glob(os.path.join(args.in_root, "*"))
 
     if len(zstack_paths) == 0:
-        print(f"{su.SFM.failure} Input directory is empty: {args.in_root}", flush=True)
+        print(f"{SFM.failure} Input directory is empty: {args.in_root}", flush=True)
         sys.exit(1)
 
     test_path = zstack_paths[0]
@@ -62,7 +63,7 @@ def main(args=None):
     try:
         su.zproj_verify_output_dir(args.out_root)
     except PermissionError as error:
-        print(f"{su.SFM.failure} {error}", flush=True)
+        print(f"{SFM.failure} {error}", flush=True)
         sys.exit(1)
 
     ### Compute Z projections ###
@@ -77,7 +78,7 @@ def main(args=None):
             for (zs_id, zsp) in zstack_paths.items()
         }
     except OSError as error:
-        print(f"{su.SFM.failure}{error}", flush=True)
+        print(f"{SFM.failure}{error}", flush=True)
         sys.exit(1)
 
     print("... Projections computed.", flush=True)
@@ -98,7 +99,7 @@ def main(args=None):
         cv2.imwrite(save_path, zproj)
 
     print("... Projections saved.", flush=True)
-    print(su.SFM.success, flush=True)
+    print(SFM.success, flush=True)
     print(su.END_SEPARATOR, flush=True)
 
     if compute_area_after_zproj:

--- a/scripts/compute_zproj.py
+++ b/scripts/compute_zproj.py
@@ -3,9 +3,7 @@ from glob import glob
 from pathlib import Path
 import subprocess
 import sys
-from typing import Optional, Union
 import numpy as np
-import numpy.typing as npt
 import cv2
 
 from fl_tissue_model_tools import defs
@@ -96,6 +94,7 @@ def main(args=None):
         img_id = z_id.replace("/", "_").replace("\\", "_")
         filename = f"{img_id}_{args.method}{out_ext}"
         save_path = os.path.join(args.out_root, filename)
+        save_path = helper.get_unique_output_filepath(save_path)
         cv2.imwrite(save_path, zproj)
 
     print("... Projections saved.", flush=True)


### PR DESCRIPTION
Changes:
- Use full z stack identifier instead of overly shortened version.
- When saving output, don't overwrite previous files. instead append number to the filename so it's unique
- decouple the colored success/failure messages dataclass `SFM` from the script_util module, create new `success_fail_messages` module for it.